### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": "^7.3 | ^8.0",
-        "codeception/codeception": "^4.1",
+        "php": "^7.3 | ^8.0 | ^8.1",
+        "codeception/codeception": "^4.1 | ^5.0",
         "zenstruck/foundry": "^1.6"
     },
     "require-dev": {


### PR DESCRIPTION
added in the next major version for codeception. as well also added newer minor versions of php. 

The php versions might be a little redundent but you could also release a secondary version v2.0 that takes everything under v8.1 out and then its ready to go. 

Symfony 6+ requires ^8.1 and then 7+ requires 8.2